### PR TITLE
Put the ModSecurity interception logic onto separated threads

### DIFF
--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -50,7 +50,7 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
-    dd("body filter, recovering ctx: %p", ctx);
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "body filter, recovering ctx: %p", ctx);
 
     if (ctx == NULL) {
         return ngx_http_next_body_filter(r, in);
@@ -155,11 +155,11 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         is_request_processed = chain->buf->last_buf;
 
         if (is_request_processed) {
-            ngx_pool_t *old_pool;
+            // ngx_pool_t *old_pool;
 
-            old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
+            // old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
             msc_process_response_body(ctx->modsec_transaction);
-            ngx_http_modsecurity_pcre_malloc_done(old_pool);
+            // ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
 /* XXX: I don't get how body from modsec being transferred to nginx's buffer.  If so - after adjusting of nginx's
    XXX: body we can proceed to adjust body size (content-length).  see xslt_body_filter() for example */
@@ -176,7 +176,7 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     }
     if (!is_request_processed)
     {
-        dd("buffer was not fully loaded! ctx: %p", ctx);
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "buffer was not fully loaded! ctx: %p", ctx);
     }
 
 /* XXX: xflt_filter() -- return NGX_OK here */

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -21,6 +21,7 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#include <ngx_thread_pool.h>
 
 #include <modsecurity/modsecurity.h>
 #include <modsecurity/transaction.h>
@@ -117,6 +118,9 @@ typedef struct {
     void                      *rules_set;
 
     ngx_flag_t                 enable;
+
+    ngx_str_t                  thread_pool_name;
+    ngx_thread_pool_t          *thread_pool;
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     ngx_flag_t                 sanity_checks_enabled;
 #endif

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -426,7 +426,7 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
 
     if (ctx == NULL)
     {
-        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "something really bad happened or ModSecurity is disabled. going to the next filter.");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "something really bad happened or ModSecurity is disabled. going to the next filter.");
         return ngx_http_next_header_filter(r);
     }
 

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -415,18 +415,18 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
     int ret = 0;
     ngx_uint_t status;
     char *http_response_ver;
-    ngx_pool_t *old_pool;
+    // ngx_pool_t *old_pool;
 
 
 /* XXX: if NOT_MODIFIED, do we need to process it at all?  see xslt_header_filter() */
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
-    dd("header filter, recovering ctx: %p", ctx);
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "header filter, recovering ctx: %p", ctx);
 
     if (ctx == NULL)
     {
-        dd("something really bad happened or ModSecurity is disabled. going to the next filter.");
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "something really bad happened or ModSecurity is disabled. going to the next filter.");
         return ngx_http_next_header_filter(r);
     }
 
@@ -442,7 +442,7 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
         /*
          * FIXME: verify if this request is already processed.
          */
-        dd("Already processed... going to the next header...");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Already processed... going to the next header...");
         return ngx_http_next_header_filter(r);
     }
 
@@ -469,13 +469,13 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
      */
     for (i = 0; ngx_http_modsecurity_headers_out[i].name.len; i++)
     {
-        dd(" Sending header to ModSecurity - header: `%.*s'.",
-            (int) ngx_http_modsecurity_headers_out[i].name.len,
-            ngx_http_modsecurity_headers_out[i].name.data);
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, " Sending header to ModSecurity - header: `%.*s'.",
+                      (int)ngx_http_modsecurity_headers_out[i].name.len,
+                      ngx_http_modsecurity_headers_out[i].name.data);
 
-                ngx_http_modsecurity_headers_out[i].resolver(r,
-                    ngx_http_modsecurity_headers_out[i].name,
-                    ngx_http_modsecurity_headers_out[i].offset);
+        ngx_http_modsecurity_headers_out[i].resolver(r,
+                                                     ngx_http_modsecurity_headers_out[i].name,
+                                                     ngx_http_modsecurity_headers_out[i].offset);
     }
 
     for (i = 0 ;; i++)
@@ -523,9 +523,9 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
     }
 #endif
 
-    old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
+    // old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
     msc_process_response_headers(ctx->modsec_transaction, status, http_response_ver);
-    ngx_http_modsecurity_pcre_malloc_done(old_pool);
+    // ngx_http_modsecurity_pcre_malloc_done(old_pool);
     ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
     if (r->error_page) {
         return ngx_http_next_header_filter(r);

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -46,7 +46,7 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1)
     {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "ModSecurity not enabled... returning");
         return NGX_DECLINED;
     }
 
@@ -63,7 +63,7 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     dd("recovering ctx: %p", ctx);
 
     if (ctx == NULL) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "something really bad happened here. returning NGX_ERROR");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "something really bad happened here. returning NGX_ERROR");
         return NGX_ERROR;
     }
 

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -47,7 +47,7 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     if (mcf == NULL || mcf->enable != 1)
     {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
-        return NGX_OK;
+        return NGX_DECLINED;
     }
 
     /*
@@ -69,7 +69,7 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
 
     if (ctx->logged) {
         ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "already logged earlier");
-        return NGX_OK;
+        return NGX_DECLINED;
     }
 
     dd("calling msc_process_logging for %p", ctx);
@@ -77,5 +77,5 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     msc_process_logging(ctx->modsec_transaction);
     ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
-    return NGX_OK;
+    return NGX_DECLINED;
 }

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -41,12 +41,12 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
-    dd("catching a new _log_ phase handler");
+    ngx_log_error(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "catching a new _log_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1)
     {
-        dd("ModSecurity not enabled... returning");
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
         return NGX_OK;
     }
 
@@ -63,12 +63,12 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     dd("recovering ctx: %p", ctx);
 
     if (ctx == NULL) {
-        dd("something really bad happened here. returning NGX_ERROR");
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "something really bad happened here. returning NGX_ERROR");
         return NGX_ERROR;
     }
 
     if (ctx->logged) {
-        dd("already logged earlier");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "already logged earlier");
         return NGX_OK;
     }
 

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -167,7 +167,7 @@ ngx_http_modsecurity_process_intervention(Transaction *transaction, ngx_http_req
         log = "(no log message was specified)";
     }
 
-    ngx_log_error(NGX_LOG_ERR, (ngx_log_t *)r->connection->log, 0, "%s", log);
+    ngx_log_error(NGX_LOG_INFO, (ngx_log_t *)r->connection->log, 0, "%s", log);
 
     if (intervention.log != NULL)
     {

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -329,6 +329,7 @@ ngx_conf_modsecurity_set_thread_pool_name(ngx_conf_t *cf, ngx_command_t *cmd, vo
     value++;
 
     tp = ngx_thread_pool_add(cf, value);
+    ngx_log_error(NGX_LOG_DEBUG, cf->log, 0, "[ModSecurity] Thread Pool Address: %p", tp);
     mcf->thread_pool = tp;
 
     return NGX_CONF_OK;
@@ -680,7 +681,7 @@ ngx_http_modsecurity_init_main_conf(ngx_conf_t *cf, void *conf)
     mmcf = (ngx_http_modsecurity_main_conf_t *)conf;
 
     ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
-                  "%s (rules loaded inline/local/remote: %ui/%ui/%ui)",
+                  "[ModSecurity] %s (rules loaded inline/local/remote: %ui/%ui/%ui)",
                   MODSECURITY_NGINX_WHOAMI, mmcf->rules_inline,
                   mmcf->rules_file, mmcf->rules_remote);
 
@@ -716,6 +717,7 @@ ngx_http_modsecurity_create_conf(ngx_conf_t *cf)
     conf->rules_set = msc_create_rules_set();
     conf->pool = cf->pool;
     conf->transaction_id = NGX_CONF_UNSET_PTR;
+    conf->thread_pool = ngx_thread_pool_add(cf, NULL);
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     conf->sanity_checks_enabled = NGX_CONF_UNSET;
 #endif

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -48,12 +48,12 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
-    dd("catching a new _preaccess_ phase handler");
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "catching a new _preaccess_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1)
     {
-        dd("ModSecurity not enabled... returning");
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
         return NGX_DECLINED;
     }
     /*
@@ -70,11 +70,11 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
-    dd("recovering ctx: %p", ctx);
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "recovering ctx: %p", ctx);
 
     if (ctx == NULL)
     {
-        dd("ctx is null; Nothing we can do, returning an error.");
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ctx is null; Nothing we can do, returning an error.");
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
@@ -84,8 +84,8 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 
     if (ctx->waiting_more_body == 1)
     {
-        dd("waiting for more data before proceed. / count: %d",
-            r->main->count);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "waiting for more data before proceed. / count: %d",
+                      r->main->count);
 
         return NGX_DONE;
     }
@@ -96,8 +96,8 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 
         ctx->body_requested = 1;
 
-        dd("asking for the request body, if any. Count: %d",
-            r->main->count);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "asking for the request body, if any. Count: %d",
+                      r->main->count);
         /**
          * TODO: Check if there is any benefit to use request_body_in_single_buf set to 1.
          *
@@ -128,7 +128,7 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         }
         if (rc == NGX_AGAIN)
         {
-            dd("nginx is asking us to wait for more data.");
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "nginx is asking us to wait for more data.");
 
             ctx->waiting_more_body = 1;
             return NGX_DONE;
@@ -140,7 +140,7 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         int ret = 0;
         int already_inspected = 0;
 
-        dd("request body is ready to be processed");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "request body is ready to be processed");
 
         r->write_event_handler = ngx_http_core_run_phases;
 
@@ -165,13 +165,13 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
              * Request body was saved to a file, probably we don't have a
              * copy of it in memory.
              */
-            dd("request body inspection: file -- %s", file_name);
+            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "request body inspection: file -- %s", file_name);
 
             msc_request_body_from_file(ctx->modsec_transaction, file_name);
 
             already_inspected = 1;
         } else {
-            dd("inspection request body in memory.");
+            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "inspection request body in memory.");
         }
 
         while (chain && !already_inspected)
@@ -221,7 +221,7 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         }
     }
 
-    dd("Nothing to add on the body inspection, reclaiming a NGX_DECLINED");
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Nothing to add on the body inspection, reclaiming a NGX_DECLINED");
 #endif
     return NGX_DECLINED;
 }

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -241,7 +241,7 @@ ngx_int_t ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1)
     {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "ModSecurity not enabled... returning");
         return NGX_DECLINED;
     }
 
@@ -261,7 +261,7 @@ ngx_int_t ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 
     if (m_ctx->waiting_more_body == 1)
     {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "waiting for more data before proceed. / count: %d",
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "waiting for more data before proceed. / count: %d",
                       r->main->count);
 
         return NGX_DONE;
@@ -308,7 +308,7 @@ ngx_int_t ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         }
         if (rc == NGX_AGAIN)
         {
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "nginx is asking us to wait for more data.");
+            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "nginx is asking us to wait for more data.");
 
             m_ctx->waiting_more_body = 1;
             return NGX_DONE;

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -20,6 +20,13 @@
 
 #include "ngx_http_modsecurity_common.h"
 
+typedef struct {
+    ngx_http_request_t *r;
+    // ngx_http_core_main_conf_t *cmcf;
+    ngx_http_modsecurity_ctx_t *ctx;
+    int return_code;
+} ngx_http_modsecurity_pre_access_thread_ctx_t;
+
 void
 ngx_http_modsecurity_request_read(ngx_http_request_t *r)
 {
@@ -29,6 +36,7 @@ ngx_http_modsecurity_request_read(ngx_http_request_t *r)
 
 #if defined(nginx_version) && nginx_version >= 8011
     r->main->count--;
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "[ModSecurity] r->main->count: %d => %d", r->main->count+1, r->main->count);
 #endif
 
     if (ctx->waiting_more_body)
@@ -40,22 +48,17 @@ ngx_http_modsecurity_request_read(ngx_http_request_t *r)
 }
 
 
-ngx_int_t
-ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
+void
+ngx_http_modsecurity_pre_access_worker(void *data, ngx_log_t *log)
 {
 #if 1
-    ngx_pool_t                   *old_pool;
-    ngx_http_modsecurity_ctx_t   *ctx;
-    ngx_http_modsecurity_conf_t  *mcf;
+    // ngx_pool_t                   *old_pool;
+    ngx_http_modsecurity_pre_access_thread_ctx_t *t_ctx = data;
+    ngx_http_modsecurity_ctx_t *ctx = t_ctx->ctx;
+    ngx_http_request_t *r = t_ctx->r;
 
-    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "catching a new _preaccess_ phase handler");
+    ngx_log_error(NGX_LOG_DEBUG, log, 0, "[ModSecurity] Pre-Access Job Dispatched");
 
-    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
-    if (mcf == NULL || mcf->enable != 1)
-    {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
-        return NGX_DECLINED;
-    }
     /*
      * FIXME:
      * In order to perform some tests, let's accept everything.
@@ -68,21 +71,195 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
     }
     */
 
-    ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
+    int ret = 0;
+    int already_inspected = 0;
 
-    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "recovering ctx: %p", ctx);
+    ngx_log_error(NGX_LOG_DEBUG, log, 0, "request body is ready to be processed");
 
-    if (ctx == NULL)
+    r->write_event_handler = ngx_http_core_run_phases;
+
+    ngx_chain_t *chain = r->request_body->bufs;
+
+    /**
+     * TODO: Speed up the analysis by sending chunk while they arrive.
+     *
+     * Notice that we are waiting for the full request body to
+     * start to process it, it may not be necessary. We may send
+     * the chunks to ModSecurity while nginx keep calling this
+     * function.
+     */
+
+    if (r->request_body->temp_file != NULL) {
+        ngx_str_t file_path = r->request_body->temp_file->file.name;
+        const char *file_name = ngx_str_to_char(file_path, r->pool);
+        if (file_name == (char*)-1) {
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
+        }
+        /*
+            * Request body was saved to a file, probably we don't have a
+            * copy of it in memory.
+            */
+        ngx_log_error(NGX_LOG_DEBUG, log, 0, "request body inspection: file -- %s", file_name);
+
+        msc_request_body_from_file(ctx->modsec_transaction, file_name);
+
+        already_inspected = 1;
+    } else {
+        ngx_log_error(NGX_LOG_DEBUG, log, 0, "inspection request body in memory.");
+    }
+
+    while (chain && !already_inspected)
     {
+        u_char *data = chain->buf->pos;
+
+        msc_append_request_body(ctx->modsec_transaction, data,
+            chain->buf->last - data);
+
+        if (chain->buf->last_buf) {
+            break;
+        }
+        chain = chain->next;
+
+/* XXX: chains are processed one-by-one, maybe worth to pass all chains and then call intervention() ? */
+
+        /**
+         * ModSecurity may perform stream inspection on this buffer,
+         * it may ask for a intervention in consequence of that.
+         *
+         */
+        ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
+        if (ret > 0) {
+            t_ctx->return_code = ret;
+            return;
+        }
+    }
+
+    /**
+     * At this point, all the request body was sent to ModSecurity
+     * and we want to make sure that all the request body inspection
+     * happened; consequently we have to check if ModSecurity have
+     * returned any kind of intervention.
+     */
+
+/* XXX: once more -- is body can be modified ?  content-length need to be adjusted ? */
+
+    // old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
+    msc_process_request_body(ctx->modsec_transaction);
+    // ngx_http_modsecurity_pcre_malloc_done(old_pool);
+
+    ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
+    if (r->error_page) {
+        t_ctx->return_code = NGX_DECLINED;
+        return;
+    }
+    if (ret > 0) {
+        t_ctx->return_code = ret;
+        return;
+    }
+    
+
+    ngx_log_error(NGX_LOG_DEBUG, log, 0, "Nothing to add on the body inspection, reclaiming a NGX_DECLINED");
+#endif
+    t_ctx->return_code = NGX_DECLINED;
+    return;
+}
+
+void ngx_http_modsecurity_pre_access_finalizer(ngx_event_t *ev){
+    ngx_http_modsecurity_pre_access_thread_ctx_t *ctx = ev->data;
+    ngx_http_core_main_conf_t *cmcf;
+
+    ngx_log_error(NGX_LOG_DEBUG, ctx->r->connection->log, 0, "[ModSecurity] Pre-Access Job Finalized");
+
+    --ctx->r->main->blocked; /* incremented in ngx_http_modsecurity_prevention_task_offload */
+    ctx->r->aio = 0;
+
+    ngx_log_error(NGX_LOG_DEBUG, ctx->r->connection->log, 0, "r->read_event_handler = %s", \
+        ctx->r->read_event_handler == ngx_http_block_reading ? \
+            "ngx_http_block_reading" : \
+        ctx->r->read_event_handler == ngx_http_test_reading ? \
+            "ngx_http_test_reading" : \
+        ctx->r->read_event_handler == ngx_http_request_empty_handler ? \
+            "ngx_http_request_empty_handler" : "UNKNOWN");
+
+    ngx_log_error(NGX_LOG_DEBUG, ctx->r->connection->log, 0, "r->write_event_handler = %s", \
+        ctx->r->write_event_handler == ngx_http_handler ? \
+            "ngx_http_handler" : \
+        ctx->r->write_event_handler == ngx_http_core_run_phases ? \
+            "ngx_http_core_run_phases" : \
+        ctx->r->write_event_handler == ngx_http_request_empty_handler ? \
+            "ngx_http_request_empty_handler" : "UNKNOWN");
+
+    cmcf = ngx_http_get_module_main_conf(ctx->r, ngx_http_core_module);
+
+    switch (ctx->return_code) {
+        case NGX_OK:
+            ctx->r->phase_handler = cmcf->phase_engine.handlers->next;
+            ngx_http_core_run_phases(ctx->r);
+            break;
+        case NGX_DECLINED:
+            ctx->r->phase_handler++;
+            ngx_http_core_run_phases(ctx->r);
+            break;
+        case NGX_AGAIN:
+        case NGX_DONE:
+            // ngx_http_core_run_phases(ctx->r);
+            break;
+        default:
+            ngx_http_discard_request_body(ctx->r);
+            ngx_http_finalize_request(ctx->r, ctx->return_code);
+        }
+
+    ngx_http_run_posted_requests(ctx->r->connection);
+}
+
+ngx_int_t ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
+{
+    ngx_http_modsecurity_conf_t *mcf;
+    ngx_http_modsecurity_pre_access_thread_ctx_t *ctx;
+    ngx_http_modsecurity_ctx_t *m_ctx;
+    ngx_thread_task_t *task;
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "catching a new _preaccess_ phase handler");
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "r->read_event_handler = %s", \
+        r->read_event_handler == ngx_http_block_reading ? \
+            "ngx_http_block_reading" : \
+        r->read_event_handler == ngx_http_test_reading ? \
+            "ngx_http_test_reading" : \
+        r->read_event_handler == ngx_http_request_empty_handler ? \
+            "ngx_http_request_empty_handler" : "UNKNOWN");
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "r->write_event_handler = %s", \
+        r->write_event_handler == ngx_http_handler ? \
+            "ngx_http_handler" : \
+        r->write_event_handler == ngx_http_core_run_phases ? \
+            "ngx_http_core_run_phases" : \
+        r->write_event_handler == ngx_http_request_empty_handler ? \
+            "ngx_http_request_empty_handler" : "UNKNOWN");
+
+    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
+    if (mcf == NULL || mcf->enable != 1)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
+        return NGX_DECLINED;
+    }
+
+    m_ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "recovering ctx: %p", m_ctx);
+
+    if (m_ctx == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ctx is null; Nothing we can do, returning an error.");
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    if (ctx->intervention_triggered) {
+    if (m_ctx->intervention_triggered)
+    {
         return NGX_DECLINED;
     }
 
-    if (ctx->waiting_more_body == 1)
+    if (m_ctx->waiting_more_body == 1)
     {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "waiting for more data before proceed. / count: %d",
                       r->main->count);
@@ -90,13 +267,13 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         return NGX_DONE;
     }
 
-    if (ctx->body_requested == 0)
+    if (m_ctx->body_requested == 0)
     {
         ngx_int_t rc = NGX_OK;
 
-        ctx->body_requested = 1;
+        m_ctx->body_requested = 1;
 
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "asking for the request body, if any. Count: %d",
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "asking for the request body, if any. Count: %d",
                       r->main->count);
         /**
          * TODO: Check if there is any benefit to use request_body_in_single_buf set to 1.
@@ -108,7 +285,8 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
          */
         r->request_body_in_single_buf = 1;
         r->request_body_in_persistent_file = 1;
-        if (!r->request_body_in_file_only) {
+        if (!r->request_body_in_file_only)
+        {
             // If the above condition fails, then the flag below will have been
             // set correctly elsewhere. We need to set the flag here for other
             // conditions (client_body_in_file_only not used but
@@ -117,11 +295,13 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         }
 
         rc = ngx_http_read_client_request_body(r,
-            ngx_http_modsecurity_request_read);
-        if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
-#if (nginx_version < 1002006) ||                                             \
+                                               ngx_http_modsecurity_request_read);
+        if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE)
+        {
+#if (nginx_version < 1002006) || \
     (nginx_version >= 1003000 && nginx_version < 1003009)
             r->main->count--;
+            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "[ModSecurity] r->main->count: %d => %d", r->main->count + 1, r->main->count);
 #endif
 
             return rc;
@@ -130,99 +310,38 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "nginx is asking us to wait for more data.");
 
-            ctx->waiting_more_body = 1;
+            m_ctx->waiting_more_body = 1;
             return NGX_DONE;
         }
     }
 
-    if (ctx->waiting_more_body == 0)
+    if (m_ctx->waiting_more_body == 0)
     {
-        int ret = 0;
-        int already_inspected = 0;
 
-        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "request body is ready to be processed");
+        task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_pre_access_thread_ctx_t));
 
-        r->write_event_handler = ngx_http_core_run_phases;
+        ctx = task->ctx;
+        ctx->r = r;
+        ctx->ctx = m_ctx;
+        ctx->return_code = NGX_DECLINED;
 
-        ngx_chain_t *chain = r->request_body->bufs;
+        task->handler = ngx_http_modsecurity_pre_access_worker;
+        task->event.handler = ngx_http_modsecurity_pre_access_finalizer;
+        task->event.data = ctx;
 
-        /**
-         * TODO: Speed up the analysis by sending chunk while they arrive.
-         *
-         * Notice that we are waiting for the full request body to
-         * start to process it, it may not be necessary. We may send
-         * the chunks to ModSecurity while nginx keep calling this
-         * function.
-         */
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "[ModSecurity] Using Thread Pool: %p", mcf->thread_pool);
 
-        if (r->request_body->temp_file != NULL) {
-            ngx_str_t file_path = r->request_body->temp_file->file.name;
-            const char *file_name = ngx_str_to_char(file_path, r->pool);
-            if (file_name == (char*)-1) {
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
-            }
-            /*
-             * Request body was saved to a file, probably we don't have a
-             * copy of it in memory.
-             */
-            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "request body inspection: file -- %s", file_name);
-
-            msc_request_body_from_file(ctx->modsec_transaction, file_name);
-
-            already_inspected = 1;
-        } else {
-            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "inspection request body in memory.");
-        }
-
-        while (chain && !already_inspected)
+        if (ngx_thread_task_post(mcf->thread_pool, task) != NGX_OK)
         {
-            u_char *data = chain->buf->pos;
-
-            msc_append_request_body(ctx->modsec_transaction, data,
-                chain->buf->last - data);
-
-            if (chain->buf->last_buf) {
-                break;
-            }
-            chain = chain->next;
-
-/* XXX: chains are processed one-by-one, maybe worth to pass all chains and then call intervention() ? */
-
-            /**
-             * ModSecurity may perform stream inspection on this buffer,
-             * it may ask for a intervention in consequence of that.
-             *
-             */
-            ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
-            if (ret > 0) {
-                return ret;
-            }
+            return NGX_ERROR;
         }
 
-        /**
-         * At this point, all the request body was sent to ModSecurity
-         * and we want to make sure that all the request body inspection
-         * happened; consequently we have to check if ModSecurity have
-         * returned any kind of intervention.
-         */
+        r->main->blocked++;
+        r->aio = 1;
 
-/* XXX: once more -- is body can be modified ?  content-length need to be adjusted ? */
-
-        old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
-        msc_process_request_body(ctx->modsec_transaction);
-        ngx_http_modsecurity_pcre_malloc_done(old_pool);
-
-        ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
-        if (r->error_page) {
-            return NGX_DECLINED;
-            }
-        if (ret > 0) {
-            return ret;
-        }
+        return NGX_DONE;
     }
 
     ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Nothing to add on the body inspection, reclaiming a NGX_DECLINED");
-#endif
     return NGX_DECLINED;
 }
-

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -303,7 +303,7 @@ ngx_int_t ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1)
     {
-        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "ModSecurity not enabled... returning");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "ModSecurity not enabled... returning");
         return NGX_DECLINED;
     }
 

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -29,7 +29,7 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1) {
-        dd("ModSecurity not enabled... returning");
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
         return NGX_DECLINED;
     }
 
@@ -42,11 +42,11 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
     }
     */
 
-    dd("catching a new _rewrite_ phase handler");
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "catching a new _rewrite_ phase handler");
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
-    dd("recovering ctx: %p", ctx);
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "recovering ctx: %p", ctx);
 
     if (ctx == NULL)
     {
@@ -61,10 +61,10 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
 
         ctx = ngx_http_modsecurity_create_ctx(r);
 
-        dd("ctx was NULL, creating new context: %p", ctx);
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "ctx was NULL, creating new context: %p", ctx);
 
         if (ctx == NULL) {
-            dd("ctx still null; Nothing we can do, returning an error.");
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ctx still null; Nothing we can do, returning an error.");
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
@@ -103,7 +103,7 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
             server_addr, server_port);
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
         if (ret != 1){
-            dd("Was not able to extract connection information.");
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "Was not able to extract connection information.");
         }
         /**
          *
@@ -114,7 +114,7 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
          * and try to use it later.
          *
          */
-        dd("Processing intervention with the connection information filled in");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Processing intervention with the connection information filled in");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 1);
         if (ret > 0) {
             ctx->intervention_triggered = 1;
@@ -156,14 +156,14 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
         if (n_uri == NULL) {
-            dd("uri is of length zero");
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "uri is of length zero");
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
         old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         msc_process_uri(ctx->modsec_transaction, n_uri, n_method, http_version);
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
-        dd("Processing intervention with the transaction information filled in (uri, method and version)");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Processing intervention with the transaction information filled in (uri, method and version)");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 1);
         if (ret > 0) {
             ctx->intervention_triggered = 1;
@@ -196,7 +196,7 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
              *
              */
 
-            dd("Adding request header: %.*s with value %.*s", (int)data[i].key.len, data[i].key.data, (int) data[i].value.len, data[i].value.data);
+            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Adding request header: %.*s with value %.*s", (int)data[i].key.len, data[i].key.data, (int)data[i].value.len, data[i].value.data);
             msc_add_n_request_header(ctx->modsec_transaction,
                 (const unsigned char *) data[i].key.data,
                 data[i].key.len,
@@ -212,7 +212,7 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         msc_process_request_headers(ctx->modsec_transaction);
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
-        dd("Processing intervention with the request headers information filled in");
+        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Processing intervention with the request headers information filled in");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 1);
         if (r->error_page) {
             return NGX_DECLINED;

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -20,20 +20,26 @@
 
 #include "ngx_http_modsecurity_common.h"
 
-ngx_int_t
-ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
-{
-    ngx_pool_t                   *old_pool;
-    ngx_http_modsecurity_ctx_t   *ctx;
-    ngx_http_modsecurity_conf_t  *mcf;
+typedef struct {
+    ngx_http_request_t *r;
+    // ngx_http_core_main_conf_t *cmcf;
+    ngx_http_modsecurity_ctx_t *ctx;
+    int return_code;
+} ngx_http_modsecurity_rewrite_thread_ctx_t;
 
-    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
-    if (mcf == NULL || mcf->enable != 1) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ModSecurity not enabled... returning");
-        return NGX_DECLINED;
-    }
+void ngx_http_modsecurity_rewrite_worker(void *data, ngx_log_t *log)
+{
+    // ngx_pool_t                   *old_pool;
+    ngx_http_modsecurity_rewrite_thread_ctx_t *t_ctx = data;
+    ngx_http_modsecurity_ctx_t *ctx = t_ctx->ctx;
+    ngx_http_request_t *r = t_ctx->r;
+
+    ngx_log_error(NGX_LOG_DEBUG, log, 0, "[ModSecurity] Rewrite Job Dispatched");
 
     /*
+     * FIXME:
+     * In order to perform some tests, let's accept everything.
+     *
     if (r->method != NGX_HTTP_GET &&
         r->method != NGX_HTTP_POST && r->method != NGX_HTTP_HEAD) {
         dd("ModSecurity is not ready to deal with anything different from " \
@@ -41,12 +47,6 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
     */
-
-    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "catching a new _rewrite_ phase handler");
-
-    ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
-
-    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "recovering ctx: %p", ctx);
 
     if (ctx == NULL)
     {
@@ -59,13 +59,16 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
          */
         ngx_str_t addr_text = connection->addr_text;
 
-        ctx = ngx_http_modsecurity_create_ctx(r);
+        t_ctx->ctx = ngx_http_modsecurity_create_ctx(r);
+        ctx = t_ctx->ctx;
 
-        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "ctx was NULL, creating new context: %p", ctx);
+        ngx_log_error(NGX_LOG_DEBUG, log, 0, "ctx was NULL, creating new context: %p", ctx);
 
-        if (ctx == NULL) {
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ctx still null; Nothing we can do, returning an error.");
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        if (ctx == NULL)
+        {
+            ngx_log_error(NGX_LOG_ERR, log, 0, "ctx still null; Nothing we can do, returning an error.");
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
         }
 
         /**
@@ -80,30 +83,37 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         int server_port = ngx_inet_get_port(connection->local_sockaddr);
 
         const char *client_addr = ngx_str_to_char(addr_text, r->pool);
-        if (client_addr == (char*)-1) {
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        if (client_addr == (char *)-1)
+        {
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
         }
 
         ngx_str_t s;
         u_char addr[NGX_SOCKADDR_STRLEN];
         s.len = NGX_SOCKADDR_STRLEN;
         s.data = addr;
-        if (ngx_connection_local_sockaddr(r->connection, &s, 0) != NGX_OK) {
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        if (ngx_connection_local_sockaddr(r->connection, &s, 0) != NGX_OK)
+        {
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
         }
 
         const char *server_addr = ngx_str_to_char(s, r->pool);
-        if (server_addr == (char*)-1) {
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        if (server_addr == (char *)-1)
+        {
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
         }
 
-        old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
+        // old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         ret = msc_process_connection(ctx->modsec_transaction,
-            client_addr, client_port,
-            server_addr, server_port);
-        ngx_http_modsecurity_pcre_malloc_done(old_pool);
-        if (ret != 1){
-            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "Was not able to extract connection information.");
+                                     client_addr, client_port,
+                                     server_addr, server_port);
+        // ngx_http_modsecurity_pcre_malloc_done(old_pool);
+        if (ret != 1)
+        {
+            ngx_log_error(NGX_LOG_WARN, log, 0, "Was not able to extract connection information.");
         }
         /**
          *
@@ -114,60 +124,74 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
          * and try to use it later.
          *
          */
-        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Processing intervention with the connection information filled in");
+        ngx_log_error(NGX_LOG_DEBUG, log, 0, "Processing intervention with the connection information filled in");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 1);
-        if (ret > 0) {
+        if (ret > 0)
+        {
             ctx->intervention_triggered = 1;
-            return ret;
+            t_ctx->return_code = ret;
+            return;
         }
 
         const char *http_version;
-        switch (r->http_version) {
-            case NGX_HTTP_VERSION_9 :
-                http_version = "0.9";
-                break;
-            case NGX_HTTP_VERSION_10 :
-                http_version = "1.0";
-                break;
-            case NGX_HTTP_VERSION_11 :
-                http_version = "1.1";
-                break;
+        switch (r->http_version)
+        {
+        case NGX_HTTP_VERSION_9:
+            http_version = "0.9";
+            break;
+        case NGX_HTTP_VERSION_10:
+            http_version = "1.0";
+            break;
+        case NGX_HTTP_VERSION_11:
+            http_version = "1.1";
+            break;
 #if defined(nginx_version) && nginx_version >= 1009005
-            case NGX_HTTP_VERSION_20 :
-                http_version = "2.0";
-                break;
+        case NGX_HTTP_VERSION_20:
+            http_version = "2.0";
+            break;
 #endif
-            default :
-                http_version = ngx_str_to_char(r->http_protocol, r->pool);
-                if (http_version == (char*)-1) {
-                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                }
-                if ((http_version != NULL) && (strlen(http_version) > 5) && (!strncmp("HTTP/", http_version, 5))) {
-                    http_version += 5;
-                } else {
-                    http_version = "1.0";
-                }
-                break;
+        default:
+            http_version = ngx_str_to_char(r->http_protocol, r->pool);
+            if (http_version == (char *)-1)
+            {
+                t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+                return;
+            }
+            if ((http_version != NULL) && (strlen(http_version) > 5) && (!strncmp("HTTP/", http_version, 5)))
+            {
+                http_version += 5;
+            }
+            else
+            {
+                http_version = "1.0";
+            }
+            break;
         }
 
         const char *n_uri = ngx_str_to_char(r->unparsed_uri, r->pool);
         const char *n_method = ngx_str_to_char(r->method_name, r->pool);
-        if (n_uri == (char*)-1 || n_method == (char*)-1) {
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        if (n_uri == (char *)-1 || n_method == (char *)-1)
+        {
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
         }
-        if (n_uri == NULL) {
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "uri is of length zero");
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        if (n_uri == NULL)
+        {
+            ngx_log_error(NGX_LOG_ERR, log, 0, "uri is of length zero");
+            t_ctx->return_code = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return;
         }
-        old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
+        // old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         msc_process_uri(ctx->modsec_transaction, n_uri, n_method, http_version);
-        ngx_http_modsecurity_pcre_malloc_done(old_pool);
+        // ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
-        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Processing intervention with the transaction information filled in (uri, method and version)");
+        ngx_log_error(NGX_LOG_DEBUG, log, 0, "Processing intervention with the transaction information filled in (uri, method and version)");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 1);
-        if (ret > 0) {
+        if (ret > 0)
+        {
             ctx->intervention_triggered = 1;
-            return ret;
+            t_ctx->return_code = ret;
+            return;
         }
 
         /**
@@ -177,9 +201,12 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         ngx_list_part_t *part = &r->headers_in.headers.part;
         ngx_table_elt_t *data = part->elts;
         ngx_uint_t i = 0;
-        for (i = 0 ; /* void */ ; i++) {
-            if (i >= part->nelts) {
-                if (part->next == NULL) {
+        for (i = 0; /* void */; i++)
+        {
+            if (i >= part->nelts)
+            {
+                if (part->next == NULL)
+                {
                     break;
                 }
 
@@ -196,12 +223,12 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
              *
              */
 
-            ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Adding request header: %.*s with value %.*s", (int)data[i].key.len, data[i].key.data, (int)data[i].value.len, data[i].value.data);
+            ngx_log_error(NGX_LOG_DEBUG, log, 0, "Adding request header: %.*s with value %.*s", (int)data[i].key.len, data[i].key.data, (int)data[i].value.len, data[i].value.data);
             msc_add_n_request_header(ctx->modsec_transaction,
-                (const unsigned char *) data[i].key.data,
-                data[i].key.len,
-                (const unsigned char *) data[i].value.data,
-                data[i].value.len);
+                                     (const unsigned char *)data[i].key.data,
+                                     data[i].key.len,
+                                     (const unsigned char *)data[i].value.data,
+                                     data[i].value.len);
         }
 
         /**
@@ -209,20 +236,101 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
          * to process this information.
          */
 
-        old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
+        // old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         msc_process_request_headers(ctx->modsec_transaction);
-        ngx_http_modsecurity_pcre_malloc_done(old_pool);
-        ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Processing intervention with the request headers information filled in");
+        // ngx_http_modsecurity_pcre_malloc_done(old_pool);
+        ngx_log_error(NGX_LOG_DEBUG, log, 0, "Processing intervention with the request headers information filled in");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 1);
-        if (r->error_page) {
-            return NGX_DECLINED;
-            }
-        if (ret > 0) {
+        // if (r->error_page)
+        // {
+        //     return NGX_DECLINED;
+        // }
+        if (!r->error_page && ret > 0)
+        {
             ctx->intervention_triggered = 1;
-            return ret;
+            t_ctx->return_code = ret;
+            return;
         }
     }
 
+    t_ctx->return_code = NGX_DECLINED;
+    return;
+}
 
-    return NGX_DECLINED;
+void ngx_http_modsecurity_rewrite_finalizer(ngx_event_t *ev)
+{
+    ngx_http_modsecurity_rewrite_thread_ctx_t *ctx = ev->data;
+    ngx_http_core_main_conf_t *cmcf;
+
+    ngx_log_error(NGX_LOG_DEBUG, ctx->r->connection->log, 0, "[ModSecurity] Rewrite Job Finalized");
+
+    --ctx->r->main->blocked; /* incremented in ngx_http_modsecurity_prevention_task_offload */
+    ctx->r->aio = 0;
+
+    cmcf = ngx_http_get_module_main_conf(ctx->r, ngx_http_core_module);
+
+    switch (ctx->return_code)
+    {
+        case NGX_OK:
+            ctx->r->phase_handler = cmcf->phase_engine.handlers->next;
+            ngx_http_core_run_phases(ctx->r);
+            break;
+        case NGX_DECLINED:
+            ctx->r->phase_handler++;
+            ngx_http_core_run_phases(ctx->r);
+            break;
+        case NGX_AGAIN:
+        case NGX_DONE:
+            // ngx_http_core_run_phases(ctx->r);
+            break;
+        default:
+            ngx_http_discard_request_body(ctx->r);
+            ngx_http_finalize_request(ctx->r, ctx->return_code);
+    }
+
+    ngx_http_run_posted_requests(ctx->r->connection);
+}
+
+ngx_int_t ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
+{
+    ngx_http_modsecurity_conf_t *mcf;
+    ngx_http_modsecurity_rewrite_thread_ctx_t *ctx;
+    ngx_http_modsecurity_ctx_t *m_ctx;
+    ngx_thread_task_t *task;
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "catching a new _rewrite_ phase handler");
+
+    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
+    if (mcf == NULL || mcf->enable != 1)
+    {
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "ModSecurity not enabled... returning");
+        return NGX_DECLINED;
+    }
+
+    m_ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "recovering ctx: %p", m_ctx);
+
+    task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_rewrite_thread_ctx_t));
+
+    ctx = task->ctx;
+    ctx->r = r;
+    ctx->ctx = m_ctx;
+    ctx->return_code = NGX_DECLINED;
+
+    task->handler = ngx_http_modsecurity_rewrite_worker;
+    task->event.handler = ngx_http_modsecurity_rewrite_finalizer;
+    task->event.data = ctx;
+
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "[ModSecurity] Using Thread Pool: %p", mcf->thread_pool);
+
+    if (ngx_thread_task_post(mcf->thread_pool, task) != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    r->main->blocked++;
+    r->aio = 1;
+
+    return NGX_DONE;
 }


### PR DESCRIPTION
This PR is created to describe my patch to fix #227 and it is by no means a complete patch ready for merge. 

The patch contains several unrelated changes, namely:

- Logger change, from `dd` to `ngx_log_error` to accomodate my own debugging need 
- Removal of `ngx_http_modsecurity_pcre_malloc_init` and `ngx_http_modsecurity_pcre_malloc_done`. They are not used in my configuration where PCRE2 is used, and it looks suspicious for SEGVs so I commented them out as a precaution.
- Why use `NGX_OK` in logging handler? Changed to `NGX_DECLINED`.

Not yet implemented:

- I'm not sure whether logging phase would take advantage of this. I did not change that yet.
- Missing a `NGX_THREADS` guard for Nginx setup without threading support.

Currently it passes all test suites and performs well in production.

Benchmarking is welcomed. 