### PR TITLE
feat: Add engine info to startup log

### DIFF
--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -661,6 +661,9 @@ ngx_http_modsecurity_init_main_conf(ngx_conf_t *cf, void *conf)
                   "%s (rules loaded inline/local/remote: %ui/%ui/%ui)",
                   MODSECURITY_NGINX_WHOAMI, mmcf->rules_inline,
                   mmcf->rules_file, mmcf->rules_remote);
+    ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+                  "libmodsecurity3 version %s.%s.%s",
+                  MODSECURITY_MAJOR, MODSECURITY_MINOR, MODSECURITY_PATCHLEVEL);
 
     return NGX_CONF_OK;
 }


### PR DESCRIPTION
This PR adds the extended information about the engine version to log during startup.

```
[notice] 940#940: ModSecurity-nginx v1.0.3 (rules loaded inline/local/remote: 0/30/0)
[notice] 940#940: libmodsecurity3 version 3.0.12
```