### PR TITLE
fix: Added missing header for conftest

### DIFF
--- a/config
+++ b/config
@@ -10,7 +10,8 @@
 
 ngx_feature_name=
 ngx_feature_run=no
-ngx_feature_incs="#include <modsecurity/modsecurity.h>"
+ngx_feature_incs="#include <modsecurity/modsecurity.h>
+#include <stdio.h>"
 ngx_feature_libs="-lmodsecurity"
 ngx_feature_test='printf("hello");'
 ngx_modsecurity_opt_I=


### PR DESCRIPTION
In `config` file the `<stdio.h>` header was missing for `printf()` function, which is used in `conftest.c` during `configure` script. This issue was discovered in Debian build system: bug id [1067364](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1067364).