### PR TITLE
New option that can disable modsecurity logging into nginx error log

### DIFF
--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -99,6 +99,7 @@ typedef struct {
     unsigned processed:1;
     unsigned logged:1;
     unsigned intervention_triggered:1;
+    ngx_uint_t status; // status code from modsecurity
 } ngx_http_modsecurity_ctx_t;
 
 

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -117,6 +117,7 @@ typedef struct {
     void                      *rules_set;
 
     ngx_flag_t                 enable;
+    ngx_flag_t                 error_log;
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     ngx_flag_t                 sanity_checks_enabled;
 #endif

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -146,6 +146,7 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
     intervention.log = NULL;
     intervention.disruptive = 0;
     ngx_http_modsecurity_ctx_t *ctx = NULL;
+    ngx_http_modsecurity_conf_t  *mcf;
 
     dd("processing intervention");
 
@@ -160,12 +161,20 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
         return 0;
     }
 
-    log = intervention.log;
-    if (intervention.log == NULL) {
-        log = "(no log message was specified)";
+    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
+    if (mcf == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    ngx_log_error(NGX_LOG_ERR, (ngx_log_t *)r->connection->log, 0, "%s", log);
+    // logging to nginx error log can be disable by setting `modsecurity_error_log` to off
+    if (mcf->error_log) {
+        log = intervention.log;
+        if (intervention.log == NULL) {
+          log = "(no log message was specified)";
+        }
+
+        ngx_log_error(NGX_LOG_ERR, (ngx_log_t *)r->connection->log, 0, "%s", log);
+    }
 
     if (intervention.log != NULL) {
         free(intervention.log);
@@ -226,7 +235,7 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
             dd("intervention -- calling log handler manually with code: %d", intervention.status);
             ngx_http_modsecurity_log_handler(r);
             ctx->logged = 1;
-	}
+	      }
 
         if (r->header_sent)
         {
@@ -465,7 +474,7 @@ static ngx_command_t ngx_http_modsecurity_commands[] =  {
     NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
     ngx_conf_set_rules,
     NGX_HTTP_LOC_CONF_OFFSET,
-    offsetof(ngx_http_modsecurity_conf_t, enable),
+    0,
     NULL
   },
   {
@@ -473,7 +482,7 @@ static ngx_command_t ngx_http_modsecurity_commands[] =  {
     NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
     ngx_conf_set_rules_file,
     NGX_HTTP_LOC_CONF_OFFSET,
-    offsetof(ngx_http_modsecurity_conf_t, enable),
+    0,
     NULL
   },
   {
@@ -481,7 +490,7 @@ static ngx_command_t ngx_http_modsecurity_commands[] =  {
     NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE2,
     ngx_conf_set_rules_remote,
     NGX_HTTP_LOC_CONF_OFFSET,
-    offsetof(ngx_http_modsecurity_conf_t, enable),
+    0,
     NULL
   },
   {
@@ -490,6 +499,14 @@ static ngx_command_t ngx_http_modsecurity_commands[] =  {
     ngx_conf_set_transaction_id,
     NGX_HTTP_LOC_CONF_OFFSET,
     0,
+    NULL
+  },
+  {
+    ngx_string("modsecurity_error_log"),
+    NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(ngx_http_modsecurity_conf_t, error_log),
     NULL
   },
   ngx_null_command
@@ -703,6 +720,7 @@ ngx_http_modsecurity_create_conf(ngx_conf_t *cf)
     conf->rules_set = msc_create_rules_set();
     conf->pool = cf->pool;
     conf->transaction_id = NGX_CONF_UNSET_PTR;
+    conf->error_log = NGX_CONF_UNSET;
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     conf->sanity_checks_enabled = NGX_CONF_UNSET;
 #endif
@@ -742,6 +760,7 @@ ngx_http_modsecurity_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(c->enable, p->enable, 0);
     ngx_conf_merge_ptr_value(c->transaction_id, p->transaction_id, NULL);
+    ngx_conf_merge_value(c->error_log, p->error_log, 1);
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     ngx_conf_merge_value(c->sanity_checks_enabled, p->sanity_checks_enabled, 0);
 #endif


### PR DESCRIPTION
Modsecurity module for nginx by default log the whole message in case request is blocked into nginx error log. But the same information is also logged into modsecurity audit logs, so logs can grow pretty fast in case of DDoS or scanning attacks. 

This patch adds new option `modsecurity_error_log` that accepts `on` or `off` option. `on` is default that logs the whole message to error log, but it can be turned off.

It also adds new variable `$modsecurity_status` that contains status code from modsecurity.