### PR TITLE
Add a Directive to get a Proxied Client's IP Address (Closes #341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)](https://zenhub.com)
 
 
-The ModSecurity-nginx connector is the connection point between nginx and libmodsecurity (ModSecurity v3). Said another way, this project provides a communication channel between nginx and libmodsecurity. This connector is required to use LibModSecurity with nginx. 
+The ModSecurity-nginx connector is the connection point between nginx and libmodsecurity (ModSecurity v3). Said another way, this project provides a communication channel between nginx and libmodsecurity. This connector is required to use LibModSecurity with nginx.
 
 The ModSecurity-nginx connector takes the form of an nginx module. The module simply serves as a layer of communication between nginx and ModSecurity.
 
@@ -176,6 +176,17 @@ using the same unique identificator.
 
 String can contain variables.
 
+modsecurity_proxy_protocol_ip
+-----------
+**syntax:** *modsecurity_proxy_protocol_ip on | off*
+
+**context:** *http, server, location*
+
+**default:** *off*
+
+If activated, ModSecurity logs the actual IP address of a client when the connections is proxied using the Proxy Protocol.
+If a connection is proxied without this directive activated, the logged IP address is the one of the proxy server.
+
 
 # Contributing
 
@@ -194,7 +205,7 @@ here: https://help.github.com/articles/using-pull-requests/
 Please respect the coding style in use. Pull requests can include various commits, so
 provide one fix or one functionality per commit. Do not change anything outside
 the scope of your target work (e.g. coding style in a function that you have
-passed by). 
+passed by).
 
 ### Don’t know where to start?
 
@@ -211,9 +222,9 @@ You may also take a look at recent bug reports and open issues to get an idea of
 ### Testing your patch
 
 Along with the manual testing, we strongly recommend that you to use the nginx test
-utility to make sure that you patch does not adversely affect the behavior or performance of nginx. 
+utility to make sure that you patch does not adversely affect the behavior or performance of nginx.
 
-The nginx tests are available on: http://hg.nginx.org/nginx-tests/ 
+The nginx tests are available on: http://hg.nginx.org/nginx-tests/
 
 To use those tests, make sure you have the Perl utility prove (part of Perl 5)
 and proceed with the following commands:
@@ -226,7 +237,7 @@ $ TEST_NGINX_BINARY=/path/to/your/nginx prove .
 
 If you are facing problems getting your added functionality to pass all the nginx tests, feel free to contact us or the nginx mailing list at: http://nginx.org/en/support.html
 
-### Debugging 
+### Debugging
 
 We respect the nginx debugging schema. By using the configuration option
 "--with-debug" during the nginx configuration you will also be enabling the

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -126,6 +126,7 @@ typedef struct {
 #endif
 
     ngx_http_complex_value_t  *transaction_id;
+    ngx_flag_t                 proxy_protocol_ip;
 } ngx_http_modsecurity_conf_t;
 
 

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -514,6 +514,14 @@ static ngx_command_t ngx_http_modsecurity_commands[] =  {
     0,
     NULL
   },
+  {
+    ngx_string("modsecurity_proxy_protocol_ip"),
+    NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(ngx_http_modsecurity_conf_t, proxy_protocol_ip),
+    NULL
+  },
   ngx_null_command
 };
 
@@ -725,6 +733,7 @@ ngx_http_modsecurity_create_conf(ngx_conf_t *cf)
     conf->rules_set = msc_create_rules_set();
     conf->pool = cf->pool;
     conf->transaction_id = NGX_CONF_UNSET_PTR;
+    conf->proxy_protocol_ip = NGX_CONF_UNSET;
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     conf->sanity_checks_enabled = NGX_CONF_UNSET;
 #endif
@@ -764,6 +773,7 @@ ngx_http_modsecurity_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(c->enable, p->enable, 0);
     ngx_conf_merge_ptr_value(c->transaction_id, p->transaction_id, NULL);
+    ngx_conf_merge_value(c->proxy_protocol_ip, p->proxy_protocol_ip, 0);
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     ngx_conf_merge_value(c->sanity_checks_enabled, p->sanity_checks_enabled, 0);
 #endif

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -78,10 +78,23 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
          * erliest phase that nginx allow us to attach those kind of hooks.
          *
          */
-        int client_port = ngx_inet_get_port(connection->sockaddr);
+        int client_port;
+
+        if (mcf->proxy_protocol_ip && connection->proxy_protocol) {
+          client_port = connection->proxy_protocol->src_port;
+        } else {
+          client_port = ngx_inet_get_port(connection->sockaddr);
+        }
         int server_port = ngx_inet_get_port(connection->local_sockaddr);
 
-        const char *client_addr = ngx_str_to_char(addr_text, r->pool);
+        const char *client_addr;
+
+        if (mcf->proxy_protocol_ip && connection->proxy_protocol) {
+          client_addr =  ngx_str_to_char(connection->proxy_protocol->src_addr, r->pool);
+        } else {
+          client_addr = ngx_str_to_char(addr_text, r->pool);
+        }
+
         if (client_addr == (char*)-1) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }


### PR DESCRIPTION
As written in #341, this patch adds functionality to obtain a client's IP address, if the request has been proxied using the Proxy Protocol.

Besides the check, if the option is enabled, I added a check if the Proxy Protocol is actually being used.