### PR TITLE
chore: fix build error with newer GCC's

### DIFF
--- a/config
+++ b/config
@@ -13,7 +13,7 @@ ngx_feature_run=no
 ngx_feature_incs="#include <modsecurity/modsecurity.h>
 #include <stdio.h>"
 ngx_feature_libs="-lmodsecurity"
-ngx_feature_test='printf("hello");'
+ngx_feature_test='msc_init();'
 ngx_modsecurity_opt_I=
 ngx_modsecurity_opt_L=
 


### PR DESCRIPTION
This PR is the same as #275, but there the sender does not want to update his patch (because of the modifications).

I want to be sure that our CI builds the module as well.