### PR TITLE
feat: set correct hostname in log produced by Nginx

### DIFF
--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -86,6 +86,44 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
+#if defined(MODSECURITY_CHECK_VERSION)
+#if MODSECURITY_VERSION_NUM >= 30130100
+        ngx_str_t hostname;
+        // first check if Nginx received a Host header and it's usable
+        // (i.e. not empty)
+        // if yes, we can use that
+        if (r->headers_in.server.len > 0) {
+            hostname.len = r->headers_in.server.len;
+            hostname.data = r->headers_in.server.data;
+        }
+        else {
+            // otherwise we try to use the server config, namely the
+            // server_name $SERVER_NAME
+            // directive
+            // for eg. in default config, server_name is "_"
+            // possible all requests without a Host header will be
+            // handled by this server block
+            ngx_http_core_srv_conf_t  *cscf;
+            cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+            if (cscf->server_name.len > 0) {
+                hostname.len = cscf->server_name.len;
+                hostname.data = cscf->server_name.data;
+            }
+        }
+        if (hostname.len > 0) {
+            const char *host_name = ngx_str_to_char(hostname, r->pool);
+            if (host_name == (char*)-1 || host_name == NULL) {
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+            else {
+                // set the hostname in the transaction
+                // this function is only available in ModSecurity 3.0.13 and later
+                msc_set_request_hostname(ctx->modsec_transaction, (const unsigned char *)host_name);
+            }
+        }
+#endif
+#endif
+
         ngx_str_t s;
         u_char addr[NGX_SOCKADDR_STRLEN];
         s.len = NGX_SOCKADDR_STRLEN;

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -89,6 +89,7 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
 #if defined(MODSECURITY_CHECK_VERSION)
 #if MODSECURITY_VERSION_NUM >= 30130100
         ngx_str_t hostname;
+        hostname.len = 0;
         // first check if Nginx received a Host header and it's usable
         // (i.e. not empty)
         // if yes, we can use that


### PR DESCRIPTION
**Reason**

There was a discussion about this feature: [#ModSecurity/3200](https://github.com/owasp-modsecurity/ModSecurity/issues/3200)

Current behavior: if ModSecurity catches an attack then it produces log entries. The problem is that the `[hostname]` field contains the server's IP address - which carries no information at all:

```
ModSecurity: Warning. ... [hostname "18.19.20.21"] [uri "/xmlrpc.php"]... client: 91.92.93.94, server: www.myserver.com, request: "POST /xmlrpc.php HTTP/1.1", host: "www.myserver.com"
```
At the end of the line, Nginx (and not ModSecurity) puts other fields, like `server` and `host`, but unfortunately those can be truncated if the other parts of line are too long, eg. `[data]` field by ModSecurity, or `request` field by Nginx, because Nginx truncates the log line after [2048](https://github.com/nginx/nginx/blob/master/src/core/ngx_log.h#L76) bytes.

The other advantage of this patch that now the fields will be the same as in case of mod_security2, so parsing the lines (hopefully) will be easier.

Note, that previously I sent a [PR](https://github.com/owasp-modsecurity/ModSecurity/pull/2906) to ModSecurity, but it was rejected. Now the result is the same but the solution is completely different, because the library gets the value from the HTTP server.

**How does it work**

In [ngx_http_modsecurity_rewrite.c](https://github.com/airween/ModSecurity-nginx/blob/sethostname/src/ngx_http_modsecurity_rewrite.c#L89-L125) there is a new block (with a compilation condition - it needs libmodsecurity3 3.0.13 at least, because [msc_set_request_hostname](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/src/transaction.cc#L2316-L2319) was implemented in that version). In this block the module try to get the `Host`  header from the request which processed by Nginx. If there is no `Host` header (eg. in case of HTTP/1.0) or the length is 0, then it gets the `server_name` value from the used virtualhost context - note, that it can be "`_`" in default config. Also if there is no `Host` header, Nginx will apply the default vhost, so the line will looks like `[hostname "_"]`.

In other cases (there **is** a `Host` header) that value will be in `[hostname]` field.
