### PR TITLE
Add an Option to Skip Body Inspections ( Closes #343 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Further information about nginx third-party add-ons support are available [here]
 # Usage
 
 ModSecurity for nginx extends your nginx configuration directives.
-It adds four new directives and they are:
+It adds six new directives and they are:
 
 modsecurity
 -----------
@@ -191,6 +191,60 @@ As an open source project we invite (and encourage) anyone from the community to
 functionality, bug fixes, bug reports, beginners user support, and anything else that you
 are willing to help with. Thank you.
 
+modsecurity_skip_req_body_filter
+-----------------
+**syntax:** *modsecurity_skip_req_body_filter on | off*
+
+**context:** *http, server, location*
+
+**default:** *off*
+
+Allows to skip the caching of the request body and subsequently its inspection.
+Useful in cases, where `SecRequestBodyAccess` or `ctl:requestBodyAccess` is set, due to, e.g. encrypted data, as the caching causes an unneeded memory overhead.
+
+
+```nginx
+server {
+    modsecurity on;
+    modsecurity_rules_file /etc/my_modsecurity_rules.conf;
+
+    location / {
+        root /var/www/html;
+    }
+
+    location = /special/unchecked/path {
+        # skip the inspection of the request body
+        modsecurity_skip_req_body_filter on;
+    }
+}
+```
+
+modsecurity_skip_resp_body_filter
+-----------------
+**syntax:** *modsecurity_skip_resp_body_filter on | off*
+
+**context:** *http, server, location*
+
+**default:** *off*
+
+Allows to skip the caching of the request body and subsequently its inspection.
+Useful in cases, where `SecResponseBodyAccess` is set, due to, e.g. encrypted data, as the caching causes an unneeded memory overhead.
+
+```nginx
+server {
+    modsecurity on;
+    modsecurity_rules_file /etc/my_modsecurity_rules.conf;
+
+    location / {
+        root /var/www/html;
+    }
+
+    location = /special/unchecked/path {
+        # skip the inspection of the response body
+        modsecurity_skip_resp_body_filter on;
+    }
+}
+```
 
 ## Providing Patches
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Further information about nginx third-party add-ons support are available [here]
 # Usage
 
 ModSecurity for nginx extends your nginx configuration directives.
-It adds six new directives and they are:
+It adds seven new directives and they are:
 
 modsecurity
 -----------

--- a/src/ngx_http_modsecurity_access.c
+++ b/src/ngx_http_modsecurity_access.c
@@ -56,6 +56,11 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
+    if(mcf->skip_req_body_filter == 1) {
+        dd("Skipping request body filter");
+        return NGX_DECLINED;
+    }
+
     /*
     if (r->method != NGX_HTTP_GET &&
         r->method != NGX_HTTP_POST && r->method != NGX_HTTP_HEAD) {

--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -39,8 +39,8 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     ngx_chain_t *chain = in;
     ngx_http_modsecurity_ctx_t *ctx = NULL;
+    ngx_http_modsecurity_conf_t *mcf = NULL;
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
-    ngx_http_modsecurity_conf_t *mcf;
     ngx_list_part_t *part = &r->headers_out.headers.part;
     ngx_table_elt_t *data = part->elts;
     ngx_uint_t i = 0;
@@ -50,7 +50,19 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         return ngx_http_next_body_filter(r, in);
     }
 
-    ctx = ngx_http_modsecurity_get_module_ctx(r);
+    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
+
+    if (mcf == NULL){
+        dd("failed to get configuration");
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (mcf->skip_resp_body_filter) {
+        dd("Skipping response body filter");
+        return ngx_http_next_body_filter(r, in);
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
     dd("body filter, recovering ctx: %p", ctx);
 
@@ -63,8 +75,7 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     }
 
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
-    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
-    if (mcf != NULL && mcf->sanity_checks_enabled != NGX_CONF_UNSET)
+    if (mcf->sanity_checks_enabled != NGX_CONF_UNSET)
     {
 #if 0
         dd("dumping stored ctx headers");

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -124,6 +124,8 @@ typedef struct {
 #endif
 
     ngx_http_complex_value_t  *transaction_id;
+    ngx_flag_t                 skip_req_body_filter;
+    ngx_flag_t                 skip_resp_body_filter;
 } ngx_http_modsecurity_conf_t;
 
 

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -529,6 +529,22 @@ static ngx_command_t ngx_http_modsecurity_commands[] =  {
     offsetof(ngx_http_modsecurity_conf_t, use_error_log),
     NULL
   },
+  {
+    ngx_string("modsecurity_skip_req_body_filter"),
+    NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(ngx_http_modsecurity_conf_t, skip_req_body_filter),
+    NULL
+  },
+  {
+    ngx_string("modsecurity_skip_resp_body_filter"),
+    NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(ngx_http_modsecurity_conf_t, skip_resp_body_filter),
+    NULL
+  },
   ngx_null_command
 };
 


### PR DESCRIPTION
As dicussed in the issue, I would like to add 2 new directives that allow to skip the body inspection. There are a few usecases, where, e.g. encrypted data is set, and no useful inspection can be made.

While denying the body access may skip the inspection, it still results in the caching of data. Subsequently, there is an unneeded amount of resource consumption, memory, as well as time, involved. 

While it would be cleaner to expose an API that allows users of `libmodsecurity` to check, if a path, e.g. has a reqeust body check, this involves a lot more work. The approach taken in this PR, shifts the functionality to that is only necessitates changes in the `nginx` module.

**Regarding Tests:** As for tests, I'm a bit unsure what the best way would be to test it. One way would be to try to upload a file, e.g. 100MB, to a location and check when the first data reaches it. If the body inspection is disabled, the first bytes will arrive much sooner, as the `nginx` module caches the body until it's fully received otherwise and only then forwards the data.