### PR TITLE
fix: free intervention.url on redirect path and check ngx_list_push r…

### DIFF
--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -208,6 +208,10 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
 
         ngx_table_elt_t *location = NULL;
         location = ngx_list_push(&r->headers_out.headers);
+        if (location == NULL) {
+            free(intervention.url);
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
         ngx_str_set(&location->key, "Location");
         location->value = a;
         r->headers_out.location = location;
@@ -217,6 +221,8 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
         ngx_http_modsecurity_store_ctx_header(r, &location->key, &location->value);
 #endif
 
+        free(intervention.url);
+        intervention.url = NULL;
         return intervention.status;
     }
 


### PR DESCRIPTION
…eturn

When ModSecurity fires a redirect intervention, intervention.url is allocated by msc_intervention() and must be freed by the caller. Previously it was leaked on every redirect, causing unbounded memory growth on busy servers using redirect-based rules.

Additionally, the ngx_list_push() call was not checked for NULL before dereferencing the returned pointer, which would cause a worker crash under out-of-memory conditions.

Fixes:
- Add free(intervention.url) before returning the redirect status code
- Add NULL check for ngx_list_push() return; free url and return 500 on allocation failure



