### PR TITLE
fix: free intervention strings on mcf NULL early return path

### DIFF
--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -163,6 +163,12 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL) {
+        if (intervention.log != NULL) {
+            free(intervention.log);
+        }
+        if (intervention.url != NULL) {
+            free(intervention.url);
+        }
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 


### PR DESCRIPTION
When msc_intervention() succeeds and fills intervention.log and/or intervention.url, then ngx_http_get_module_loc_conf() returns NULL (unexpected misconfiguration), the function returned immediately with NGX_HTTP_INTERNAL_SERVER_ERROR without freeing either string.

Free both intervention.log and intervention.url before the early return to prevent the leak on this error path.


