### PR TITLE
fix: replace strdup(error) with nginx pool allocation in config handlers

### DIFF
--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -367,7 +367,7 @@ ngx_conf_set_rules(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (res < 0) {
         dd("Failed to load the rules: '%s' - reason: '%s'", rules, error);
-        return ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
+        return (char *) ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
     }
 
     mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_modsecurity_module);
@@ -401,7 +401,7 @@ ngx_conf_set_rules_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (res < 0) {
         dd("Failed to load the rules from: '%s' - reason: '%s'", rules_set, error);
-        return ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
+        return (char *) ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
     }
 
     mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_modsecurity_module);
@@ -440,7 +440,7 @@ ngx_conf_set_rules_remote(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (res < 0) {
         dd("Failed to load the rules from: '%s'  - reason: '%s'", rules_remote_server, error);
-        return ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
+        return (char *) ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
     }
 
     mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_modsecurity_module);

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -367,7 +367,7 @@ ngx_conf_set_rules(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (res < 0) {
         dd("Failed to load the rules: '%s' - reason: '%s'", rules, error);
-        return strdup(error);
+        return ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
     }
 
     mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_modsecurity_module);
@@ -401,7 +401,7 @@ ngx_conf_set_rules_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (res < 0) {
         dd("Failed to load the rules from: '%s' - reason: '%s'", rules_set, error);
-        return strdup(error);
+        return ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
     }
 
     mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_modsecurity_module);
@@ -440,7 +440,7 @@ ngx_conf_set_rules_remote(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (res < 0) {
         dd("Failed to load the rules from: '%s'  - reason: '%s'", rules_remote_server, error);
-        return strdup(error);
+        return ngx_pstrdup(cf->pool, &(ngx_str_t){ngx_strlen(error), (u_char *)error});
     }
 
     mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_modsecurity_module);

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -580,7 +580,7 @@ ngx_http_modsecurity_init(ngx_conf_t *cf)
     }
     /**
      *
-     * We want to process everything in the NGX_HTTP_ACCESS_PHASE because we need to allow 
+     * We want to process everything in the NGX_HTTP_ACCESS_PHASE because we need to allow
      * ngx_http_limit_*_module to run
      *
      */


### PR DESCRIPTION
In ngx_conf_set_rules, ngx_conf_set_rules_file, and ngx_conf_set_rules_remote, rule load errors returned a strdup()- allocated string. Nginx treats the returned char* as a constant string and never frees it, causing a heap leak on every failed nginx -s reload when rule files have errors.

Replace with ngx_pstrdup(cf->pool, ...) so the error string is allocated from the config pool and freed automatically when nginx reloads configuration.

