### PR TITLE
fix: fail closed on swallowed WAF return values

### DIFF
--- a/src/ngx_http_modsecurity_access.c
+++ b/src/ngx_http_modsecurity_access.c
@@ -415,13 +415,19 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
              */
             dd("request body inspection: file -- %s", file_name);
 
-            if (msc_request_body_from_file(ctx->modsec_transaction, file_name) != 1) {
-                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                    "ModSecurity: failed to submit file-buffered request "
-                    "body for inspection");
-                ctx->intervention_triggered = 1;
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
-            }
+            /*
+             * msc_request_body_from_file()/msc_append_request_body() return
+             * 0 not only on a genuine failure but also -- indistinguishably,
+             * from the caller's side -- whenever SecRequestBodyLimitAction
+             * is ProcessPartial and the body exceeds SecRequestBodyLimit:
+             * libmodsecurity deliberately truncates at the limit and
+             * reports it the same way (see Transaction::appendRequestBody(),
+             * which is what requestBodyFromFile() delegates to). That is
+             * normal, by-design behavior, not an inspection bypass -- the
+             * truncated content is still evaluated -- so it must not fail
+             * the request closed.
+             */
+            msc_request_body_from_file(ctx->modsec_transaction, file_name);
 
             already_inspected = 1;
         } else {
@@ -432,15 +438,12 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         {
             u_char *data = chain->buf->pos;
 
-            if (msc_append_request_body(ctx->modsec_transaction, data,
-                chain->buf->last - data) != 1)
-            {
-                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                    "ModSecurity: failed to append request body chunk "
-                    "for inspection");
-                ctx->intervention_triggered = 1;
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
-            }
+            /* See the comment on msc_request_body_from_file() above: 0 here
+             * means either a real failure or (indistinguishably) a
+             * by-design ProcessPartial truncation, so it must not fail
+             * closed. */
+            msc_append_request_body(ctx->modsec_transaction, data,
+                chain->buf->last - data);
 
             if (chain->buf->last_buf) {
                 break;

--- a/src/ngx_http_modsecurity_access.c
+++ b/src/ngx_http_modsecurity_access.c
@@ -182,6 +182,10 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
             ctx->intervention_triggered = 1;
             return ret;
         }
+        else if (ret < 0) {
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
 
         const char *http_version;
         switch (r->http_version) {
@@ -230,6 +234,10 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         if (ret > 0) {
             ctx->intervention_triggered = 1;
             return ret;
+        }
+        else if (ret < 0) {
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
         /**
@@ -282,6 +290,10 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         if (ret > 0) {
             ctx->intervention_triggered = 1;
             return ret;
+        }
+        else if (ret < 0) {
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
     }
 
@@ -403,7 +415,13 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
              */
             dd("request body inspection: file -- %s", file_name);
 
-            msc_request_body_from_file(ctx->modsec_transaction, file_name);
+            if (msc_request_body_from_file(ctx->modsec_transaction, file_name) != 1) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "ModSecurity: failed to submit file-buffered request "
+                    "body for inspection");
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
 
             already_inspected = 1;
         } else {
@@ -414,8 +432,15 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         {
             u_char *data = chain->buf->pos;
 
-            msc_append_request_body(ctx->modsec_transaction, data,
-                chain->buf->last - data);
+            if (msc_append_request_body(ctx->modsec_transaction, data,
+                chain->buf->last - data) != 1)
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "ModSecurity: failed to append request body chunk "
+                    "for inspection");
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
 
             if (chain->buf->last_buf) {
                 break;
@@ -431,7 +456,12 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
              */
             ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
             if (ret > 0) {
+                ctx->intervention_triggered = 1;
                 return ret;
+            }
+            else if (ret < 0) {
+                ctx->intervention_triggered = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
             }
         }
 
@@ -445,16 +475,28 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
 /* XXX: once more -- is body can be modified ?  content-length need to be adjusted ? */
 
         old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
-        msc_process_request_body(ctx->modsec_transaction);
-        ctx->request_body_processed = 1;
+        ret = msc_process_request_body(ctx->modsec_transaction);
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
+        ctx->request_body_processed = 1;
+
+        if (ret != 1) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "ModSecurity: request body phase processing failed");
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
 
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
         if (r->error_page) {
             return NGX_DECLINED;
             }
         if (ret > 0) {
+            ctx->intervention_triggered = 1;
             return ret;
+        }
+        else if (ret < 0) {
+            ctx->intervention_triggered = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
     }
 

--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -146,16 +146,20 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         u_char *data = chain->buf->pos;
         int ret;
 
-        if (msc_append_response_body(ctx->modsec_transaction, data,
-            chain->buf->last - data) != 1)
-        {
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                "ModSecurity: failed to append response body chunk "
-                "for inspection");
-            ctx->intervention_triggered = 1;
-            return ngx_http_filter_finalize_request(r,
-                &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
-        }
+        /*
+         * msc_append_response_body() returns 0 not only on a genuine
+         * failure but also -- indistinguishably, from the caller's side --
+         * whenever SecResponseBodyLimitAction is ProcessPartial and the
+         * body exceeds SecResponseBodyLimit: libmodsecurity deliberately
+         * truncates at the limit and reports it the same way (see
+         * Transaction::appendResponseBody(), whose own docstring is
+         * "@retval false Operation failed, process partial demanded"). That
+         * is normal, by-design behavior, not an inspection bypass -- the
+         * truncated content is still evaluated -- so it must not fail the
+         * request closed.
+         */
+        msc_append_response_body(ctx->modsec_transaction, data,
+            chain->buf->last - data);
 
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
         if (ret > 0) {

--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -164,9 +164,21 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 &ngx_http_modsecurity_module, ret);
         }
         else if (ret < 0) {
+            /*
+             * process_intervention() returns -1 specifically when
+             * r->header_sent is already true (it wanted to intervene but
+             * can't safely rewrite headers). By the time the body filter
+             * runs, header_sent is *always* true -- header_filter() already
+             * ran. ngx_http_filter_finalize_request() would call
+             * ngx_http_clean_header() and try to send a fresh status line
+             * and headers anyway, producing nginx's own "header already
+             * sent" alert and a truncated response instead of a clean
+             * abort. NGX_ERROR is the correct signal here: it triggers
+             * ngx_http_terminate_request(), which closes the connection
+             * without attempting to resend anything.
+             */
             ctx->intervention_triggered = 1;
-            return ngx_http_filter_finalize_request(r,
-                &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return NGX_ERROR;
         }
 
 /* XXX: chain->buf->last_buf || chain->buf->last_in_chain */
@@ -195,10 +207,9 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 return ret;
             }
             else if (ret < 0) {
+                /* See the comment on the identical check above. */
                 ctx->intervention_triggered = 1;
-                return ngx_http_filter_finalize_request(r,
-                    &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
-
+                return NGX_ERROR;
             }
         }
     }

--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -146,11 +146,27 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         u_char *data = chain->buf->pos;
         int ret;
 
-        msc_append_response_body(ctx->modsec_transaction, data, chain->buf->last - data);
+        if (msc_append_response_body(ctx->modsec_transaction, data,
+            chain->buf->last - data) != 1)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                "ModSecurity: failed to append response body chunk "
+                "for inspection");
+            ctx->intervention_triggered = 1;
+            return ngx_http_filter_finalize_request(r,
+                &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        }
+
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
         if (ret > 0) {
+            ctx->intervention_triggered = 1;
             return ngx_http_filter_finalize_request(r,
                 &ngx_http_modsecurity_module, ret);
+        }
+        else if (ret < 0) {
+            ctx->intervention_triggered = 1;
+            return ngx_http_filter_finalize_request(r,
+                &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
         }
 
 /* XXX: chain->buf->last_buf || chain->buf->last_in_chain */
@@ -160,16 +176,26 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             ngx_pool_t *old_pool;
 
             old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
-            msc_process_response_body(ctx->modsec_transaction);
+            ret = msc_process_response_body(ctx->modsec_transaction);
             ngx_http_modsecurity_pcre_malloc_done(old_pool);
+
+            if (ret != 1) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "ModSecurity: response body phase processing failed");
+                ctx->intervention_triggered = 1;
+                return ngx_http_filter_finalize_request(r,
+                    &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            }
 
 /* XXX: I don't get how body from modsec being transferred to nginx's buffer.  If so - after adjusting of nginx's
    XXX: body we can proceed to adjust body size (content-length).  see xslt_body_filter() for example */
             ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r, 0);
             if (ret > 0) {
+                ctx->intervention_triggered = 1;
                 return ret;
             }
             else if (ret < 0) {
+                ctx->intervention_triggered = 1;
                 return ngx_http_filter_finalize_request(r,
                     &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
 

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -537,9 +537,16 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
         return ngx_http_filter_finalize_request(r, &ngx_http_modsecurity_module, ret);
     }
     else if (ret < 0) {
+        /*
+         * process_intervention() returns -1 specifically when
+         * r->header_sent is already true. ngx_http_filter_finalize_request()
+         * would try to send a fresh status line and headers anyway via
+         * ngx_http_clean_header(), producing nginx's own "header already
+         * sent" alert. NGX_ERROR triggers ngx_http_terminate_request()
+         * instead, which just closes the connection.
+         */
         ctx->intervention_triggered = 1;
-        return ngx_http_filter_finalize_request(r,
-            &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
     }
 
     /*

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -533,7 +533,13 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
         return ngx_http_next_header_filter(r);
     }
     if (ret > 0) {
+        ctx->intervention_triggered = 1;
         return ngx_http_filter_finalize_request(r, &ngx_http_modsecurity_module, ret);
+    }
+    else if (ret < 0) {
+        ctx->intervention_triggered = 1;
+        return ngx_http_filter_finalize_request(r,
+            &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
     }
 
     /*

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -290,12 +290,23 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
 
     if (mcf->transaction_id) {
         if (ngx_http_complex_value(r, mcf->transaction_id, &s) != NGX_OK) {
-            return NGX_CONF_ERROR;
+            return NULL;
         }
         ctx->modsec_transaction = msc_new_transaction_with_id(mmcf->modsec, mcf->rules_set, (char *) s.data, r->connection->log);
 
     } else {
         ctx->modsec_transaction = msc_new_transaction(mmcf->modsec, mcf->rules_set, r->connection->log);
+    }
+
+    /*
+     * A NULL transaction here would make every later msc_* call inspect
+     * nothing (fail-open) while the request/response is still forwarded.
+     * Fail closed instead: the caller turns a NULL ctx into a 500.
+     */
+    if (ctx->modsec_transaction == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "ModSecurity: failed to create transaction");
+        return NULL;
     }
 
     dd("transaction created");
@@ -306,7 +317,7 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
     if (cln == NULL)
     {
         dd("failed to create the ModSecurity context cleanup");
-        return NGX_CONF_ERROR;
+        return NULL;
     }
     cln->handler = ngx_http_modsecurity_cleanup;
     cln->data = ctx;
@@ -314,7 +325,7 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     ctx->sanity_headers_out = ngx_array_create(r->pool, 12, sizeof(ngx_http_modsecurity_header_t));
     if (ctx->sanity_headers_out == NULL) {
-        return NGX_CONF_ERROR;
+        return NULL;
     }
 #endif
 

--- a/tests/modsecurity-response-body-deny.t
+++ b/tests/modsecurity-response-body-deny.t
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+
+#
+# ModSecurity, http://www.modsecurity.org/
+# Copyright (c) 2015 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+#
+# You may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# If any of the files related to licensing are missing or if you have any
+# other questions related to licensing please contact Trustwave Holdings, Inc.
+# directly using the email address security@modsecurity.org.
+#
+
+
+# Regression test for a phase-4 RESPONSE_BODY "deny" action.
+#
+# By the time msc_process_response_body() detects a violation, response
+# headers (status, Content-Length) have already been sent to the client --
+# this connector does not delay headers until body inspection completes.
+# ngx_http_modsecurity_body_filter() used to report that via
+# ngx_http_filter_finalize_request(), which tries to send a *fresh* status
+# line and headers regardless (via nginx's own ngx_http_clean_header()).
+# Since headers were already flushed, this produced nginx's own "header
+# already sent" [alert] and a corrupted response instead of a clean abort.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        modsecurity on;
+        modsecurity_rules_file %%TESTDIR%%/rules.conf;
+
+        location / {
+        }
+    }
+}
+EOF
+
+$t->write_file('rules.conf', <<'EOF');
+SecRuleEngine On
+SecResponseBodyAccess On
+SecResponseBodyMimeType text/plain
+SecRule RESPONSE_BODY "@rx leakmarker" "id:103,phase:4,deny,status:403"
+EOF
+
+# The marker sits at the end of a large body, so the deny only fires once
+# the whole response is buffered -- well after headers went out.
+$t->write_file('leak.txt', ('x' x 8192) . "leakmarker\n");
+$t->write_file('clean.txt', ('x' x 8192) . "\n");
+
+$t->run();
+$t->plan(3);
+
+###############################################################################
+
+my $clean = http_get('/clean.txt');
+like($clean, qr/^HTTP\/1\.[01] 200/, 'benign response body passes');
+
+my $leak = http_get('/leak.txt');
+# Whether the connection drops before any bytes go out (a response that fits
+# in one buffer) or mid-transfer after a partial prefix (a larger,
+# multi-buffer response), the leak marker itself is never delivered: it only
+# triggers the deny once msc_process_response_body() has read the full
+# buffered body, which happens strictly before that data is forwarded.
+unlike($leak, qr/leakmarker/, 'leak marker body was not delivered to the client');
+
+my $d = $t->testdir();
+my $errorlog = do {
+    local $/ = undef;
+    open my $fh, "<", "$d/error.log" or die "could not open: $!";
+    <$fh>;
+};
+unlike($errorlog, qr/header already sent/, 'no "header already sent" alert from the deny path');
+
+###############################################################################


### PR DESCRIPTION
## Summary

- `msc_process_request_body()` and `msc_process_response_body()` signal failure via their return value (`1` = success, `0` = failure per libmodsecurity's C API), but every call site in `ngx_http_modsecurity_access.c` / `ngx_http_modsecurity_body_filter.c` discarded it and kept forwarding the request/response as if it had been fully inspected. They now check the return value and fail closed with a 500.
- `ngx_http_modsecurity_process_intervention()` can return `-1` (`NGX_ERROR`) when it wants to block or redirect but headers were already sent. Most call sites only checked for a positive return, silently letting the request/response through uninspected. All call sites in `ngx_http_modsecurity_access.c`, `ngx_http_modsecurity_body_filter.c` and `ngx_http_modsecurity_header_filter.c` now handle it.
- `ctx->intervention_triggered` was only set on some of the blocking paths, so a later filter invocation for the same request could re-run the WAF on an already-finished transaction. It's now set consistently on every early-return path.
- `ngx_http_modsecurity_create_ctx()` never checked whether `msc_new_transaction()`/`msc_new_transaction_with_id()` returned `NULL`, and three of its own error paths returned `NGX_CONF_ERROR` (`(void*)-1`) instead of `NULL` — the only caller only checks for `NULL`, so that sentinel was never caught and would have dereferenced a bogus pointer instead of cleanly failing with a 500.

### Added: phase-4 RESPONSE_BODY blocking always corrupted the response

While building a local libmodsecurity + nginx stack to actually verify the `ret < 0` handling above (rather than just reasoning about the code), I found that the `-1` case added above was itself broken on arrival.

`process_intervention()` returns `-1` specifically when `r->header_sent` is already `true` — it wants to intervene but can't safely rewrite headers. By the time the body filter runs, `header_sent` is **always** true (this connector doesn't delay response headers until body inspection finishes), so *every* phase-4/5 `RESPONSE_BODY` deny/block/redirect hits this branch. Both `ret < 0` sites in `ngx_http_modsecurity_body_filter.c` called `ngx_http_filter_finalize_request()`, which calls nginx's own `ngx_http_clean_header()` and tries to send a *fresh* status line and headers regardless — since headers had already gone out, this produced nginx's own `[alert] header already sent` and delivered a corrupted response instead of a clean block.

Confirmed with an instrumented build: `ret` was `-1` with `header_sent=1` on every phase-4 deny I triggered — the positive/redirect case those branches were apparently also written to cover can't actually occur here, since `process_intervention()` can only return a positive status when `header_sent` is false, which never holds in the body filter.

Fix: return `NGX_ERROR` instead. nginx's own `ngx_http_finalize_request()` treats `NGX_ERROR` as "abort the connection, don't try to build a response" (`ngx_http_terminate_request()`) — the correct behavior once headers can no longer be rewritten. For a response that fits in one buffer this drops the connection before anything goes out; for a larger, multi-buffer response the client sees however much had already been forwarded, then the connection closes — never anything resembling a complete, successfully-served response. Added `tests/modsecurity-response-body-deny.t`, confirmed to fail on the pre-fix code (`[alert] header already sent`) and pass with this fix.

### Fixed: CI caught a real regression — reverted the fail-closed check on the `append_*`/`*_from_file` calls

CI (`modsecurity-config-merge.t`, `modsecurity-request-body.t`) failed on every `SecRequestBodyLimitAction ProcessPartial` / `SecResponseBodyLimitAction ProcessPartial` scenario, always returning 500 instead of passing.

Root cause: `msc_append_request_body()` / `msc_append_response_body()` / `msc_request_body_from_file()` return `0` not only on a genuine failure but also — indistinguishably, from the caller's side — whenever the relevant `*BodyLimitAction` is `ProcessPartial` and the body exceeds the configured limit. `Transaction::appendRequestBody()`/`appendResponseBody()` in libmodsecurity deliberately truncate at the limit and report it via the exact same return value as a real failure (`appendResponseBody()`'s own docstring is literally `@retval false Operation failed, process partial demanded`). `requestBodyFromFile()` delegates to `appendRequestBody()`, so it inherits the same ambiguity. This is normal, by-design behavior — the truncated content is still evaluated by the subsequent `process_request_body()`/`process_response_body()` call — not an inspection bypass, so my original "fail closed on any non-1 return" was wrong for these three specific functions. Reverted to the original behavior for just those three (ignore the return value); `msc_process_request_body()`/`msc_process_response_body()` don't have this ambiguity (the reference implementation always returns success there regardless of body limit) and keep their fail-closed check, as does the `process_intervention()` `ret < 0` handling.

## Test plan

- [x] Built libmodsecurity v3 + nginx locally (macOS) against both the pre-fix and fixed code; confirmed with `curl -v` that the pre-fix build corrupts the response (200 headers already sent, then "header already sent" alert, then truncated/duplicated body) and the fixed build cleanly aborts the connection instead, for both a single-buffer (small) and multi-buffer (large) response.
- [x] `tests/modsecurity-response-body-deny.t` added; ran it directly against both binaries via `nginx-tests` — fails on the pre-fix code (`[alert] header already sent`), passes with the fix.
- [x] CI caught the `ProcessPartial` regression on `linux-gcc`/`linux-clang` across all three nginx versions; reproduced locally, fixed, and re-ran `modsecurity-config-merge.t` + `modsecurity-request-body.t` + `modsecurity-response-body-deny.t` against a rebuilt binary — all pass.
- [ ] CI: full green run across all matrix jobs (Linux passing as of the latest push; the unrelated `windows-nginx-*` failures on this and other open PRs are a flaky third-party tarball download in `test_new.yml`'s "Set up third-party libraries" step, not caused by this change).
