### PR TITLE
fix: header registration visibility and body-loop edge case

### DIFF
--- a/src/ngx_http_modsecurity_access.c
+++ b/src/ngx_http_modsecurity_access.c
@@ -103,7 +103,7 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         int server_port = ngx_inet_get_port(connection->local_sockaddr);
 
         const char *client_addr = ngx_str_to_char(addr_text, r->pool);
-        if (client_addr == (char*)-1) {
+        if (client_addr == (char*)-1 || client_addr == NULL) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
@@ -155,7 +155,7 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
         }
 
         const char *server_addr = ngx_str_to_char(s, r->pool);
-        if (server_addr == (char*)-1) {
+        if (server_addr == (char*)-1 || server_addr == NULL) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
@@ -259,11 +259,16 @@ ngx_http_modsecurity_access_handler(ngx_http_request_t *r)
              */
 
             dd("Adding request header: %.*s with value %.*s", (int)data[i].key.len, data[i].key.data, (int) data[i].value.len, data[i].value.data);
-            msc_add_n_request_header(ctx->modsec_transaction,
+            if (msc_add_n_request_header(ctx->modsec_transaction,
                 (const unsigned char *) data[i].key.data,
                 data[i].key.len,
                 (const unsigned char *) data[i].value.data,
-                data[i].value.len);
+                data[i].value.len) != 1)
+            {
+                ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                    "ModSecurity: failed to add request header \"%V\" "
+                    "for inspection", &data[i].key);
+            }
         }
 
         /**

--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -174,6 +174,16 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                     &ngx_http_modsecurity_module, NGX_HTTP_INTERNAL_SERVER_ERROR);
 
             }
+
+            /*
+             * msc_process_response_body() is a one-shot finalize. A filter
+             * upstream of us (sub_filter, gzip, ...) may append a trailing
+             * buffer after the last_buf link in the same chain; without this
+             * break we'd loop into it and call msc_append_response_body()
+             * again on an already-finalized transaction. The full chain is
+             * still forwarded below regardless of where we stop inspecting.
+             */
+            break;
         }
     }
     if (!is_request_processed)

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -321,11 +321,16 @@ ngx_http_modsecurity_resolv_header_connection(ngx_http_request_t *r, ngx_str_t n
             ngx_http_modsecurity_store_ctx_header(r, &name2, &value);
 #endif
 
-            msc_add_n_response_header(ctx->modsec_transaction,
+            if (msc_add_n_response_header(ctx->modsec_transaction,
                 (const unsigned char *) name2.data,
                 name2.len,
                 (const unsigned char *) value.data,
-                value.len);
+                value.len) != 1)
+            {
+                ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                    "ModSecurity: failed to add response header "
+                    "\"%V\" for inspection", &name2);
+            }
         }
     } else {
         connection = "close";
@@ -475,9 +480,15 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
             (int) ngx_http_modsecurity_headers_out[i].name.len,
             ngx_http_modsecurity_headers_out[i].name.data);
 
-                ngx_http_modsecurity_headers_out[i].resolver(r,
+                if (ngx_http_modsecurity_headers_out[i].resolver(r,
                     ngx_http_modsecurity_headers_out[i].name,
-                    ngx_http_modsecurity_headers_out[i].offset);
+                    ngx_http_modsecurity_headers_out[i].offset) != 1)
+                {
+                    ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                        "ModSecurity: failed to add response header "
+                        "\"%V\" for inspection",
+                        &ngx_http_modsecurity_headers_out[i].name);
+                }
     }
 
     for (i = 0 ;; i++)
@@ -500,11 +511,16 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
         /*
          * Doing this ugly cast here, explanation on the request_header
          */
-        msc_add_n_response_header(ctx->modsec_transaction,
+        if (msc_add_n_response_header(ctx->modsec_transaction,
             (const unsigned char *) data[i].key.data,
             data[i].key.len,
             (const unsigned char *) data[i].value.data,
-            data[i].value.len);
+            data[i].value.len) != 1)
+        {
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                "ModSecurity: failed to add response header \"%V\" "
+                "for inspection", &data[i].key);
+        }
     }
 
     /* prepare extra paramters for msc_process_response_headers() */


### PR DESCRIPTION
## Summary

- `msc_add_n_request_header()` and `msc_add_n_response_header()` signal failure via their return value, but every call site discarded it — the resolver dispatch loop in `ngx_http_modsecurity_header_filter()`, the raw `headers_out`/`headers_in` list loops, and the nested `Keep-Alive` add inside `ngx_http_modsecurity_resolv_header_connection()`. A failure (OOM inside libmodsecurity) meant that header simply never reached the WAF with no visibility into it. These now log a warning on failure. Unlike the request/response body phase (handled in a separate PR), dropping a single header isn't equivalent to skipping inspection outright, so this logs rather than fails the request closed.
- `ngx_str_to_char()` returns `NULL` for a zero-length `ngx_str_t` (not an error, just "empty"), and most callers already check for it (e.g. `n_uri`, `host_name`), but `client_addr` and `server_addr` in the connection-info block didn't. An empty `addr_text` (e.g. some unix-socket configurations) would pass `NULL` straight into `msc_process_connection()`, which expects a C string.
- The response-body loop in `ngx_http_modsecurity_body_filter()` never broke out after running `msc_process_response_body()` on the buffer carrying `last_buf`. A filter upstream of us (`sub_filter`, gzip, ...) can append a trailing buffer after the `last_buf` link in the same chain, which would loop back around and call `msc_append_response_body()` again on an already-finalized transaction. The full chain is still forwarded to the next filter regardless of where this loop stops inspecting, so nothing is dropped from the response.

## Test plan

- [ ] Build against libmodsecurity v3 and run the existing `tests/*.t` suite (`prove modsecurity*.t`) to confirm no regression.