### PR TITLE
ci: retry pcre2/zlib/openssl downloads in build-windows

### DIFF
--- a/.github/workflows/test_new.yml
+++ b/.github/workflows/test_new.yml
@@ -332,12 +332,26 @@ jobs:
       - name: Set up third-party libraries
         working-directory: nginx
         run: |
+          set -euo pipefail
           mkdir objs
           mkdir objs/lib
           cd objs/lib
-          wget -q -O - https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.gz | tar -xzf -
-          wget -q -O - https://www.zlib.net/fossils/zlib-1.3.2.tar.gz | tar -xzf -
-          wget -q -O - https://www.openssl.org/source/openssl-3.6.2.tar.gz | tar -xzf -
+          # Download to a file (with retries) before extracting, rather than
+          # piping straight into tar: a retried download restarts the
+          # response from byte 0, and a live pipe already mid-consumed by
+          # tar can't rewind -- it would just get a second copy of the file
+          # appended after the truncated first one, corrupting the archive.
+          # A file-based retry cleanly overwrites the previous attempt.
+          for url in \
+            https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.gz \
+            https://www.zlib.net/fossils/zlib-1.3.2.tar.gz \
+            https://www.openssl.org/source/openssl-3.6.2.tar.gz \
+          ; do
+            archive="$(basename "$url")"
+            wget --tries=3 --retry-connrefused --waitretry=5 -O "$archive" "$url"
+            tar -xzf "$archive"
+            rm "$archive"
+          done
       - name: Get libModSecurity source
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Fixes #388.

The `build-windows` job's "Set up third-party libraries" step piped `wget` directly into `tar` with no retry:

```yaml
wget -q -O - https://.../pcre2-10.47.tar.gz | tar -xzf -
```

A single truncated download (`gzip: stdin: unexpected end of file` / `tar: Child returned status 1`) killed the whole job immediately, with `-q` hiding which of the three downloads actually failed.

- Download to a file first (`wget --tries=3 --retry-connrefused --waitretry=5 -O "$archive" "$url"`), then extract, rather than piping straight into `tar`. This isn't just cosmetic: piping can't be retried safely in the first place — a retried request restarts the response from byte 0, but `tar` has already consumed whatever the first, truncated attempt streamed through the pipe. A retry there would just append a second copy of the file after the truncated first one, corrupting the archive instead of fixing anything. A file-based retry cleanly overwrites the previous attempt.
- `set -euo pipefail` added explicitly at the top of the step, so any failure (including from `wget` itself) is fail-fast rather than silently continuing.

## Test plan

- [x] `shellcheck`/`shfmt` clean on the extracted script.
- [x] `actionlint`/`zizmor` show no *new* findings versus the file's current state (the existing unpinned-action/artipacked/cmd-shell findings elsewhere in this file are pre-existing and out of scope for this fix).
- [ ] CI: confirm `build-windows` gets past this step reliably. Note per #388's own writeup: this job also hits a **separate, unrelated, deterministic** failure further along (yajl/CMake `CMP0026` incompatibility, tracked upstream as [owasp-modsecurity/ModSecurity#3604](https://github.com/owasp-modsecurity/ModSecurity/issues/3604)), so `build-windows` won't go fully green until that's also fixed — this PR only addresses the flaky download this step itself is responsible for.